### PR TITLE
3-crear-un-nuevo-endpoint-que-actualice-el-estado-usando-el-caso-de-uso-del-punto-anterior

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
  - Agregar las propiedades `email` y `address` a las compañías. Estado: :+1:
  - Crear un nuevo caso de uso para actualizar el estado de una compañía de `inactive` a `active`. Estado: :+1:
- - Crear un nuevo endpoint de API que actualice el estado usando el caso de uso del punto anterior. Estado:
+ - Crear un nuevo endpoint de API que actualice el estado usando el caso de uso del punto anterior. Estado: :+1:
  - Crear nuevo caso de uso que liste todas las compañías. Estado:
  - Crear un nuevo endpoint de API que liste las compañías en base al caso de uso del punto anterior. Estado:
  - Los test deben pasar después de realizar los cambios. Estado:

--- a/app/Http/Controllers/Api/Company/PathUpdateStatusCompanyController.php
+++ b/app/Http/Controllers/Api/Company/PathUpdateStatusCompanyController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Api\Company;
+
+use Illuminate\Support\Facades\DB;
+use App\Http\Controllers\Controller;
+use App\Models\Company as ModelsCompany;
+use Vocces\Company\Application\CompanyUpdateStatus;
+use Vocces\Company\Domain\ValueObject\CompanyStatus;
+
+class PathUpdateStatusCompanyController extends Controller
+{
+    /**
+     * Update company
+     *
+     * @param  ModelsCompany $company
+     * @param  CompanyUpdateStatus $service
+     */
+    public function __invoke(ModelsCompany $company ,CompanyUpdateStatus $service )
+    {
+        DB::beginTransaction();
+        try {
+            $companyStatus= new CompanyStatus(1);
+            $return = $service->handle($company, $companyStatus->name());
+            DB::commit();
+            return response($return->toArray(),201);
+        } catch (\Throwable $error) {
+            DB::rollback();
+            throw $error;
+        }
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -22,5 +22,6 @@ class Company extends Model
         'name',
         'email',
         'address',
+        'status',
     ];
 }

--- a/database/migrations/2024_04_25_172706_add_status_companies.php
+++ b/database/migrations/2024_04_25_172706_add_status_companies.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStatusCompanies extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->string('status')->after('address');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('companies', function($table) {
+            $table->dropColumn('status');
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,3 +15,4 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::post('/company', [App\Http\Controllers\Api\Company\PostCreateCompanyController::class, '__invoke']);
+Route::patch('/company/{company}', [App\Http\Controllers\Api\Company\PathUpdateStatusCompanyController::class, '__invoke']);

--- a/src/Company/Application/CompanyUpdateStatus.php
+++ b/src/Company/Application/CompanyUpdateStatus.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Vocces\Company\Application;
-use Vocces\Company\Domain\Company;
+use App\Models\Company as ModelsCompany;
 use Vocces\Company\Domain\CompanyRepositoryInterface;
 use Vocces\Shared\Domain\Interfaces\ServiceInterface;
 
@@ -23,9 +23,9 @@ class CompanyUpdateStatus implements ServiceInterface
     /**
      * Update a status the 'inactive' to 'active'
      */
-    public function handle(Company $company)
+    public function handle(ModelsCompany $company,string $companiStatus )
     {
-         $this->repository->changeStatus($company);
-        return $company->status();
+         $this->repository->changeStatus($company,$companiStatus);
+        return $company;
     }
 }

--- a/src/Company/Domain/CompanyRepositoryInterface.php
+++ b/src/Company/Domain/CompanyRepositoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace Vocces\Company\Domain;
 
+use App\Models\Company as ModelsCompany;
 use Vocces\Company\Domain\ValueObject\CompanyStatus;
 
 interface CompanyRepositoryInterface
@@ -14,5 +15,5 @@ interface CompanyRepositoryInterface
      * @return void
      */
     public function create(Company $company): void;
-    public function changeStatus(Company $company): void;
+    public function changeStatus(ModelsCompany $company,string $companyStatus): void;
 }

--- a/src/Company/Infrastructure/CompanyRepositoryEloquent.php
+++ b/src/Company/Infrastructure/CompanyRepositoryEloquent.php
@@ -18,11 +18,13 @@ class CompanyRepositoryEloquent implements CompanyRepositoryInterface
             'name'   => $company->name(),
             'email'   => $company->email(),
             'address'   => $company->address(),
-            'status' => $company->status(),
+            'status' => $company->status()->name(),
         ]);
     }
-    public function changeStatus(Company $company): void
+    public function changeStatus(ModelsCompany $company, string $companyStatus ): void
     {
-        $company->status()->enabled();
+
+        $company->status = $companyStatus;
+        $company->save();
     }
 }

--- a/tests/Vocces/Company/Infrastructure/CompanyRepositoryFake.php
+++ b/tests/Vocces/Company/Infrastructure/CompanyRepositoryFake.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Vocces\Company\Infrastructure;
 
+use App\Models\Company as ModelsCompany;
 use Vocces\Company\Domain\Company;
 use Vocces\Company\Domain\CompanyRepositoryInterface;
 
@@ -16,7 +17,7 @@ class CompanyRepositoryFake implements CompanyRepositoryInterface
     {
         $this->callMethodCreate = true;
     }
-    public function changeStatus(Company $company): void
+    public function changeStatus(ModelsCompany $company, string $companyStatus): void
     {
         $this->callMethodCreate = true;
     }

--- a/tests/Vocces/Company/Routes/UpdateStatusCompanyRouteTest.php
+++ b/tests/Vocces/Company/Routes/UpdateStatusCompanyRouteTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Vocces\Company\Routes;
+
+use App\Models\Company;
+use Tests\TestCase;
+use Vocces\Company\Application\CompanyCreator;
+use Tests\Vocces\Company\Infrastructure\CompanyRepositoryFake;
+use Illuminate\Support\Str;
+class UpdateStatusCompanyRouteTest extends TestCase
+{
+    /**
+     * @group route
+     * @group access-interface
+     * @test
+     */
+    public function updateStatusCompanyRoute()
+    {
+        /**
+         * Preparing
+         */
+        $faker = \Faker\Factory::create();
+        $testCompany = [
+            'id'     => Str::uuid(),
+            'name'   => $faker->name,
+            'email'   => $faker->email,
+            'address'   => $faker->address,
+            'status'   => 'inactive'
+        ];
+        $company= Company::create($testCompany);
+        /**
+         * Actions
+         */
+        $response = $this->json('PATCH', '/api/company/'.$company->id->toString());
+        //dd($response);
+        /**
+         * Asserts
+         */
+           $response->assertStatus(201)
+                      ->assertJsonFragment(['status'=>'active']);
+    }
+}


### PR DESCRIPTION
Se ha creado un endpoint para pasar de inactivo a activo el modelo del punto anterior, ademas se han modificado los archivos para que se tenga la expasibilidad suficiente como para poder cambiar de estado entre ellos facilmente
Como punto clave se ha generado un test de ruta ya que los endpoint deben de tener un test.